### PR TITLE
fix up buildObject type definition so it infers the returned ObjectType

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,9 +94,9 @@
       "dev": true
     },
     "@types/iobroker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-3.2.4.tgz",
-      "integrity": "sha512-1AoNluSXarWKWY4Jz8BWE155WsA4fCVwZIAKnUajHp+lAud5L27bAJHNaehTB7ADJaOU7pDPTdMeeq38uZaPTg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-3.2.5.tgz",
+      "integrity": "sha512-EUCE42mPqsquq7eWfnC1Q7B6LtcD/A+Sao9zUAq8db2Y9ygdyE+lIN79JNI/pxZkk8K9DOMFnOE9G78YM8DN/Q==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/clone-deep": "^4.0.1",
-    "@types/iobroker": "^3.2.4",
+    "@types/iobroker": "^3.2.5",
     "@types/node": "^14.14.6",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",

--- a/src/lib/object_attributes.ts
+++ b/src/lib/object_attributes.ts
@@ -1,12 +1,12 @@
-import { CommonAttributes, CommonAttributeSchema, ObjectCommonSchema, ObjectTypes } from "./types";
+import { CommonAttributes, CommonAttributeSchema, ObjectCommonSchema } from "./types";
 
 // This type is used to statically validate the schema below for correct type and correct properties
 type ValidatedCommonSchema<T extends Record<keyof T, any>> = {
 	// For all missing object types add the required type
-	[key in Exclude<ObjectTypes, keyof T>]: ObjectCommonSchema<ioBroker.AnyObject & { type: key }>;
+	[key in Exclude<ioBroker.ObjectType, keyof T>]: ObjectCommonSchema<ioBroker.AnyObject & { type: key }>;
 } & {
 	// For each property in the given object, check if @types/iobroker has this object type
-	[key in keyof T]: key extends ObjectTypes
+	[key in keyof T]: key extends ioBroker.ObjectType
 		// If yes, try to combine the definition and what we were given
 		? ObjectCommonSchema<ioBroker.AnyObject & { type: key }> & T[key]
 		// If not, make a type error, so we can add it to @types/iobroker
@@ -34,9 +34,7 @@ export const objectCommonSchemas = validateCommonSchema({
 			"desc",
 			"min",
 			"max",
-			// step currently missing in official definition, but integrated in schema.md
-			// Issue in Adapter-Core opened: https://github.com/ioBroker/adapter-core/issues/283
-			//"step",
+			"step",
 			"unit",
 			"states",
 			"workingID",
@@ -81,15 +79,15 @@ export const objectCommonSchemas = validateCommonSchema({
 		"desc": "A host that runs a controller process",
 		"attrMandatory": [
 			"name",
-			"version",
-			"platform",
+			"title",
+			"installedVersion",
 			"cmd",
 			"hostname",
+			"type",
+			"platform",
 			"address"
 		],
-		"attrOptional": [
-			"process"
-		]
+		"attrOptional": []
 	},
 	"adapter": {
 		"desc": "The default config of an adapter. Presence also indicates that the adapter is successfully installed.",
@@ -109,11 +107,12 @@ export const objectCommonSchemas = validateCommonSchema({
 			"type"
 		],
 		"attrOptional": [
-			"adminTab.fa-icon",
-			"adminTab.ignoreConfigUpdate",
-			"adminTab.link",
-			"adminTab.name",
-			"adminTab.singleton",
+			// TODO: We cannot currently check nested properties
+			// "adminTab.fa-icon",
+			// "adminTab.ignoreConfigUpdate",
+			// "adminTab.link",
+			// "adminTab.name",
+			// "adminTab.singleton",
 			"allowInit",
 			"availableModes",
 			"blockly",
@@ -134,12 +133,13 @@ export const objectCommonSchemas = validateCommonSchema({
 			"noConfig",
 			"noIntro",
 			"noRepository",
-			"noGit",
+			"nogit",
 			"nondeletable",
 			"onlyWWW",
-			"osDependencies.darwin",
-			"osDependencies.linux",
-			"osDependencies.win32",
+			// TODO: We cannot currently check nested properties
+			// "osDependencies.darwin",
+			// "osDependencies.linux",
+			// "osDependencies.win32",
 			"os",
 			"preserveSettings",
 			"restartAdapters",
@@ -153,7 +153,7 @@ export const objectCommonSchemas = validateCommonSchema({
 			"subscribe",
 			"supportCustoms",
 			"supportStopInstance",
-			"unchanged",
+			// "unchanged",
 			"unsafePerm",
 			"wakeup",
 			"webByVersion",
@@ -162,10 +162,9 @@ export const objectCommonSchemas = validateCommonSchema({
 			"webPreSettings",
 			"webservers",
 			"welcomeScreen",
-			"welcomeScreen.order",
+			// "welcomeScreen.order",
 			"welcomeScreenPro",
-			"wwwDontUpload",
-			"protectedNative"
+			"wwwDontUpload"
 		]
 	},
 	"instance": {
@@ -183,14 +182,19 @@ export const objectCommonSchemas = validateCommonSchema({
 		"desc": "Configuration object"
 	},
 	"script": {
-		"desc": "Represenst a script",
+		"desc": "Represents a script",
 		"attrMandatory": [
-			"platform",
+			"engineType",
 			"enabled",
 			"source"
 		],
 		"attrOptional": [
-			"engine"
+			"engine",
+			"debug",
+			"verbose",
+			"sourceHash",
+			"compiled",
+			"declarations"
 		]
 	},
 	"user": {
@@ -207,7 +211,8 @@ export const objectCommonSchemas = validateCommonSchema({
 			"members"
 		],
 		"attrOptional": [
-			"desc"
+			// TODO: I didn't find this in the documentation
+			// "desc"
 		]
 	},
 	// Info is in Type Definitions, but missing in documentation
@@ -217,12 +222,10 @@ export const objectCommonSchemas = validateCommonSchema({
 		"attrMandatory": [
 			"name"
 		]
+	},
+	"chart": {
+		"desc": "Represents a chart (e.g. for flot)"
 	}
-	// Same as step, included in schema but missing in defintion
-	// Same issue as step: https://github.com/ioBroker/adapter-core/issues/283
-	//"chart": {
-	//	"desc": "Represents a chart (e.g. for flot)"
-	//}
 });
 
 // This type is used to statically validate the schema below for correct type and correct properties
@@ -273,12 +276,12 @@ export const commonAttributes = validateCommonAttributes({
 		"attrType": "number"
 	},
 	// Currently missing in type definitions, Issue create
-	//"step": {
-	//	"desc": "Increase/decrease interval",
-	//	"type": "number",
-	//	"write": true,
-	//	"attrType": "number"
-	//},
+	"step": {
+		"desc": "Increase/decrease interval",
+		"type": "number",
+		"write": true,
+		"attrType": "number"
+	},
 	"unit": {
 		"desc": "The unit of the value",
 		"type": "number",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,15 +1,6 @@
 // This combination of types defines the possible shapes of the template objects based on what the ioBroker type definitions offer us
-type TemplateObjectWorker<T extends ioBroker.AnyObject> = Pick<T, "type" | "common">;
-export type TemplateObjectDefinition =
-	| TemplateObjectWorker<ioBroker.StateObject>
-	| TemplateObjectWorker<ioBroker.ChannelObject>
-	| TemplateObjectWorker<ioBroker.DeviceObject>
-	| TemplateObjectWorker<ioBroker.FolderObject>
-	| TemplateObjectWorker<ioBroker.EnumObject>
-	| TemplateObjectWorker<ioBroker.OtherObject>;
-
-// TODO: in ioBroker.ObjectType are only state, channel and device defined
-export type ObjectTypes = ioBroker.AnyObject["type"];
+type TemplateObjectWorker<T extends ioBroker.AnyObject> = T extends ioBroker.AnyObject ? Pick<T, "type" | "common"> : never;
+export type TemplateObjectDefinition = TemplateObjectWorker<ioBroker.AnyObject>;
 
 /** Defines the mandatory and optional common attributes of an ioBroker object */
 export interface ObjectCommonSchema<T extends ioBroker.AnyObject> {

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,43 @@
+// This file is a playground to test the function signatures
+
+import { buildObject } from "./main";
+
+const iobObj1 = buildObject(undefined as any, {
+	id: "statistics.total_distance_meter",
+	name: "total_distance_meter",
+	value: "test",
+	objectType: "state",
+	role: "value",
+	description: "Total distance in meters",
+});
+iobObj1.object.common.unit = "m";
+
+const iobObj2 = buildObject(undefined as any, {
+	id: "statistics.total_distance_meter",
+	name: "total_distance_meter",
+	value: "test",
+	objectType: "template",
+	template: "alive",
+	description: "Total distance in meters",
+});
+iobObj2.object.common.unit = "m";
+
+const iobObj3 = buildObject(undefined as any, {
+	id: "statistics.total_distance_meter",
+	name: "total_distance_meter",
+	value: "test",
+	objectType: "template",
+	template: "device",
+	description: "Total distance in meters",
+});
+// Expected error:
+iobObj3.object.common.unit = "m";
+
+const iobObj4 = buildObject(undefined as any, {
+	id: "statistics.total_distance_meter",
+	name: "total_distance_meter",
+	value: "test",
+	objectType:"state",
+	role: "adapter.messagebox"
+});
+iobObj4;


### PR DESCRIPTION
fixes: #18

This PR is blocked by the pending update of @types/iobroker. The PR is merged but the package is not yet released.
To test, copy the `index.d.ts` and `objects.d.ts` from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/iobroker into `node_modules/@types/iobroker`.